### PR TITLE
Add support for building with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: android
+
+android:
+  components:
+    - build-tools-19.0.0
+
+notifications:
+  email: false
+
+env:
+  matrix:
+    - ANDROID_SDKS=android-19,sysimg-19  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
+
+before_install:
+  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
+
+before_script:
+  - ./scripts/wait_for_emulator.sh
+  - adb shell input keyevent 82 &

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,4 +44,8 @@ android {
         minSdkVersion 10
         targetSdkVersion 19
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }

--- a/scripts/wait_for_emulator.sh
+++ b/scripts/wait_for_emulator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+bootanim=""
+failcounter=0
+until [[ "$bootanim" =~ "stopped" ]]; do
+   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1`
+   echo "$bootanim"
+   if [[ "$bootanim" =~ "not found" ]]; then
+      let "failcounter += 1"
+      if [[ $failcounter -gt 3 ]]; then
+        echo "Failed to start emulator"
+        exit 1
+      fi
+   fi
+   sleep 1
+done
+echo "Done"


### PR DESCRIPTION
Add build script (.travis.yml) for travis-ci.org support. Also updates
android/build.gradle to make linter errors non-fatal.
