### PR TITLE
Restore scripts/wait_for_emulator.sh

### DIFF
--- a/scripts/wait_for_emulator.sh
+++ b/scripts/wait_for_emulator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+bootanim=""
+failcounter=0
+until [[ "$bootanim" =~ "stopped" ]]; do
+   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1`
+   echo "$bootanim"
+   if [[ "$bootanim" =~ "not found" ]]; then
+      let "failcounter += 1"
+      if [[ $failcounter -gt 3 ]]; then
+        echo "Failed to start emulator"
+        exit 1
+      fi
+   fi
+   sleep 1
+done
+echo "Done"


### PR DESCRIPTION
This script is used as part of our test suite for Travis CI, and is
needed to prevent the build from failing. (Or to be more accurate, to
allow the tests to run at all.)
