### PR TITLE
Fixed a string comparison.

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/model/ScheduleItem.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/model/ScheduleItem.java
@@ -85,7 +85,7 @@ public class ScheduleItem implements Cloneable, Comparable<ScheduleItem> {
         }
         ScheduleItem i = (ScheduleItem) o;
         return type == i.type &&
-                sessionId == i.sessionId &&
+                sessionId.equals(i.sessionId) &&
                 startTime == i.startTime &&
                 endTime == i.endTime;
     }


### PR DESCRIPTION
The reference comparison of the two strings may work in some situations because of string pooling, but I don't think that's how it was intended.
