### PR TITLE
correct translation of string decline in zh-rCN

### DIFF
--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -127,7 +127,7 @@
 
     <!-- Label on a button that the user clicks to decline something (for example, a license
     agreement). -->
-    <string name="decline">下降</string>
+    <string name="decline">拒绝</string>
 
     <!-- Menu item that brings up the application's About screen -->
     <string name="description_about">关于</string>


### PR DESCRIPTION
decline should be translated into "拒绝" but not "下降" in Chinese simplified
