### PR TITLE
Parameterise keystore properties

### DIFF
--- a/Wearable/build.gradle
+++ b/Wearable/build.gradle
@@ -36,16 +36,16 @@ android {
     }
     signingConfigs {
         debug {
-            storeFile file("../android/debug.keystore")
-            storePassword "android"
-            keyAlias "androiddebugkey"
-            keyPassword "android"
+            storeFile file(iosched14_android_debugkey_storefile)
+            storePassword iosched14_android_debugkey_storePassword
+            keyAlias iosched14_android_debugkey_keyAlias
+            keyPassword iosched14_android_debugkey_keyPassword
         }
         release {
-            storeFile file("../android/debug.keystore")
-            storePassword "android"
-            keyAlias "androiddebugkey"
-            keyPassword "android"
+            storeFile file(iosched14_android_releasekey_storefile)
+            storePassword iosched14_android_releasekey_storePassword
+            keyAlias iosched14_android_releasekey_keyAlias
+            keyPassword iosched14_android_releasekey_keyPassword
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,24 @@
+#
+# Properties for the build which can be overridden locally.
+# 
+# This allows build keys to be set where the app is being built in 
+# a gradle.properties override. See;
+#
+#  http://www.gradle.org/docs/current/userguide/tutorial_this_and_that.html#sec:gradle_properties_and_system_properties
+# 
+# for more information on the overriding system.
+#
+
+# The store file location is relative to the module base, and so needs to go
+# up one level of the directory hierarchy to get to the project root.
+
+iosched14_android_debugkey_storefile = ../android/debug.keystore
+iosched14_android_debugkey_storePassword = android
+iosched14_android_debugkey_keyAlias = androiddebugkey
+iosched14_android_debugkey_keyPassword = android
+
+iosched14_android_releasekey_storefile = ../android/debug.keystore
+iosched14_android_releasekey_storePassword = android
+iosched14_android_releasekey_keyAlias = androiddebugkey
+iosched14_android_releasekey_keyPassword = android
+


### PR DESCRIPTION
Parameterise the keystore location so it can be overridden by environment level or command line properties. This allows developers to keep their keystore information outside of the project and pass it into the build using either a user level properties file or via the command line.

The default behaviour is the same as the existing code.
