### PR TITLE
Address gradle deprecation warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-lpreview = hasProperty('lpreview')
+lpreview = hasProperty('lpreview') ? lpreview.toBoolean() : false;
 
 apply plugin: 'com.android.application'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+#
+# Properties for the build which can be overridden locally.
+# 
+# This allows build keys to be set where the app is being built in 
+# a gradle.properties override. See;
+#
+#  http://www.gradle.org/docs/current/userguide/tutorial_this_and_that.html#sec:gradle_properties_and_system_properties
+# 
+# for more information on the overriding system.
+#
+
+# Whether we are building the L-preview version or not.
+
+lpreview = false


### PR DESCRIPTION
Address the following warning by putting the lpreview variable in gradle.properties;

```
Creating properties on demand (a.k.a. dynamic properties) has been deprecated and is scheduled to be removed in Gradle 2.0. Please read http://gradle.org/docs/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html for information on the replacement for dynamic properties.
```

[Unfortunately gradle doesn't auto-cast the value to a boolean so an explicit cast is needed.]
