### PR TITLE
Fix comment typo 'backgorund' -> 'background'

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/ui/BaseActivity.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/BaseActivity.java
@@ -160,7 +160,7 @@ public abstract class BaseActivity extends Activity implements
     // SwipeRefreshLayout allows the user to swipe the screen down to trigger a manual refresh
     private SwipeRefreshLayout mSwipeRefreshLayout;
 
-    // asynctask that performs GCM registration in the backgorund
+    // asynctask that performs GCM registration in the background
     private AsyncTask<Void, Void, Void> mGCMRegisterTask;
 
     // handle to our sync observer (that notifies us about changes in our sync state)


### PR DESCRIPTION
Corrects a typo in BaseActivity. Original was 'backgorund' and was correct to 'background'
