### PR TITLE
Fix .travis.yml, typo in android-19 component name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ language: android
 android:
   components:
     - build-tools-20.0.0
-    - andorid-19
+    - android-19
     - android-20
     - extra-google-m2repository
     - extra-android-m2repository


### PR DESCRIPTION
Typo in android-19 component name. It's preinstalled but android sounds better :)
http://docs.travis-ci.com/user/languages/android/#Pre-installed-components
