### PR TITLE
Remove unused translations without default string

### DIFF
--- a/android/src/main/res/values-de/strings.xml
+++ b/android/src/main/res/values-de/strings.xml
@@ -469,11 +469,6 @@
     <string name="schedule_end_time">bis <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>\n<xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">Sitzungen suchen</string>
 

--- a/android/src/main/res/values-es/strings.xml
+++ b/android/src/main/res/values-es/strings.xml
@@ -467,11 +467,6 @@
     <string name="schedule_end_time">a <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>\n<xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">Buscar sesiones</string>
 

--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -471,12 +471,6 @@
     <string name="schedule_end_time">à <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>
-    <xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">Rechercher les sessions</string>
 

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -460,11 +460,6 @@
     <string name="schedule_end_time">
     <xliff:g id="endTime">%1$s</xliff:g>まで</string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g> <xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">セッション検索</string>
 

--- a/android/src/main/res/values-ko/strings.xml
+++ b/android/src/main/res/values-ko/strings.xml
@@ -465,11 +465,6 @@
     <string name="schedule_end_time">- <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>\n<xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">세션 검색</string>
 

--- a/android/src/main/res/values-pt/strings.xml
+++ b/android/src/main/res/values-pt/strings.xml
@@ -468,11 +468,6 @@
     <string name="schedule_end_time">até <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>\n<xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">Buscar sessões</string>
 

--- a/android/src/main/res/values-ru/strings.xml
+++ b/android/src/main/res/values-ru/strings.xml
@@ -481,11 +481,6 @@
     <string name="schedule_end_time">до <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>\n<xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">Поиск событий</string>
 

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -464,11 +464,6 @@
     <string name="schedule_end_time">至<xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g>\n<xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">搜索会议</string>
 

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -463,11 +463,6 @@
     <string name="schedule_end_time">直到 <xliff:g id="endTime">%1$s</xliff:g>
   </string>
 
-    <!-- -->
-    <string name="schedule_session_subtitle">
-    <xliff:g id="speakers">%1$s</xliff:g> <xliff:g id="room">%2$s</xliff:g>
-  </string>
-
     <!-- Hint that the user can search across sessions -->
     <string name="search_hint">搜索會議</string>
 


### PR DESCRIPTION
```
Lint shows the next warnings about unused translations.
If you are not planning to use them, this commit removes the transtations
(Or add default strings, so there are less risks and clear warnings)

:android:processDebugResources
warning: string 'navdrawer_description_a11y' has no default translation.
warning: string 'navdrawer_item_app_feedback' has no default translation.
warning: string 'navdrawer_item_app_feedback_a11y' has no default translation.
warning: string 'schedule_session_subtitle' has no default translation.
warning: string 'title_stream' has no default translation.
warning: string 'schedule_session_subtitle' has no deafult transtation.
```
