### PR TITLE
Update travis.yml for lollipop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,19 @@ language: android
 
 android:
   components:
-    - build-tools-20.0.0
-    - android-19
+    - build-tools-21.0.1
     - android-20
+    - android-21
     - extra-google-m2repository
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-20
+    - sys-img-armeabi-v7a-android-21
 
 notifications:
   email: false
 
 env:
   matrix:
-    - ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-21  ANDROID_ABI=armeabi-v7a
 
 before_install:
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI


### PR DESCRIPTION
Updated build-tools to rev 21.0.1
Updated android component, image and target to 21

I never used Travis and i dont know if they support upgrades by default etc., so be aware.
I send it because i saw: "failed to find target android-21 : /usr/local/android-sdk" in my last pull request.
