### PR TITLE
Update build tools rev 21.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ language: android
 
 android:
   components:
-    - build-tools-21.0.1
+    - build-tools-21.0.2
     - android-20
     - android-21
     - extra-google-m2repository

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.0.1"
+    buildToolsVersion "21.0.2"
 
     defaultConfig {
         minSdkVersion 14

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -49,7 +49,7 @@ To build the app:
        - Tools > Android SDK Platform-tools (rev 21 or above)
        - Tools > Android SDK Tools (rev 23.0.5 or above)
        - Tools > Android SDK Build-tools version 20
-       - Tools > Android SDK Build-tools version 21 (rev 21.0.1 or above)
+       - Tools > Android SDK Build-tools version 21 (rev 21.0.2 or above)
        - Android 4.4W > SDK Platform (API 20)
        - Android 5.0 > SDK Platform (API 21)
        - Extras > Android Support Repository


### PR DESCRIPTION
Updated build tools to rev 21.0.2 in android build.gradle, building doc and travis.yml
This rev. solves the windows users issue:
https://code.google.com/p/android/issues/detail?id=77629

Travis wont work until they upgrade or you install 23.0.5 sdk manually,
emulator or something i dont know do. I ll wait your/their solution.
http://docs.travis-ci.com/user/languages/android/
https://github.com/travis-ci/travis-cookbooks/blob/master/ci_environment/android-sdk/CHANGELOG.md
