### PR TITLE
Update BUILDING.md

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -49,7 +49,7 @@ This is a Gradle-based project that works best with [Android Studio].
        - Tools > Android SDK Tools (rev 23.0.5 or above)
        - Tools > Android SDK Build-tools version 20
        - Tools > Android SDK Build-tools version 21 (rev 21.0.2 or above)
-       - Android 4.4W > SDK Platform (API 20)
+       - Android 4.4W2 > SDK Platform (API 20)
        - Android 5.0 > SDK Platform (API 21)
        - Extras > Android Support Repository
        - Extras > Android Support Library


### PR DESCRIPTION
Yesterday I had some issues following the building doc as-is. 
1. In the server-side setup section is a tiny but confusing error; where it says "the API key from step 5" it should be step 6 instead (that is due to the numbered list currently starts with 0 instead of 1).
2. A few Windows-specifics were missing
3. In the regular building instructions it is no referrer to the App Signing docs. However, if this is the very first time you build a project, the given instructions are confusing and not enough.

This PR tries to solve these (and a few more, related) "issues" by adding missing information and reformatting confusing instructions. You can see my modified version of the building doc here:
https://github.com/eyecatchup/iosched/blob/master/doc/BUILDING.md - compared to: 
https://github.com/google/iosched/blob/master/doc/BUILDING.md

BTW, unlike the server-side setup guide says (Step 3), I did **not** required the project Id from cloud console in order to successfully create a release build of the IOSched android module. SignIn, Maps, YT.. everything works just fine?! So that was a bit confusing too.
