### PR TITLE
Use an empty ArrayList for each session being sychronsied

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/sync/FeedbackSyncHelper.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/sync/FeedbackSyncHelper.java
@@ -54,12 +54,12 @@ public class FeedbackSyncHelper {
                 null,
                 null);
         LOGD(TAG, "Number of unsynced feedbacks: " + c.getCount());
-        List<String> questions = new ArrayList<String>();
         List<String> updatedSessions = new ArrayList<String>();
 
         while (c.moveToNext()) {
             String sessionId = c.getString(c.getColumnIndex(ScheduleContract.Feedback.SESSION_ID));
 
+	        List<String> questions = new ArrayList<String>();
             questions.add(c.getString(c.getColumnIndex(ScheduleContract.Feedback.SESSION_RATING)));
             questions.add(c.getString(c.getColumnIndex(ScheduleContract.Feedback.ANSWER_RELEVANCE)));
             questions.add(c.getString(c.getColumnIndex(ScheduleContract.Feedback.ANSWER_CONTENT)));

--- a/android/src/main/java/com/google/samples/apps/iosched/sync/FeedbackSyncHelper.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/sync/FeedbackSyncHelper.java
@@ -59,7 +59,7 @@ public class FeedbackSyncHelper {
         while (c.moveToNext()) {
             String sessionId = c.getString(c.getColumnIndex(ScheduleContract.Feedback.SESSION_ID));
 
-	        List<String> questions = new ArrayList<String>();
+            List<String> questions = new ArrayList<String>();
             questions.add(c.getString(c.getColumnIndex(ScheduleContract.Feedback.SESSION_RATING)));
             questions.add(c.getString(c.getColumnIndex(ScheduleContract.Feedback.ANSWER_RELEVANCE)));
             questions.add(c.getString(c.getColumnIndex(ScheduleContract.Feedback.ANSWER_CONTENT)));


### PR DESCRIPTION
Fix for Issue #77 - Ensure a new ArrayList is used for each session feedback being synchronised.

(This could also be achieved by clearing the questions array list, but doing things this way allows the HTTP communication to the server to be offloaded to another Thread at some point in the future without any concerns about the object values being altered)