### PR TITLE
Set CALLER_IS_SYNCADAPTER inside FeedbackSyncHelper

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/sync/FeedbackSyncHelper.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/sync/FeedbackSyncHelper.java
@@ -81,7 +81,9 @@ public class FeedbackSyncHelper {
         ContentValues contentValues = new ContentValues();
         contentValues.put(ScheduleContract.Feedback.SYNCED, 1);
         for (String sessionId : updatedSessions) {
-            cr.update(ScheduleContract.Feedback.buildFeedbackUri(sessionId), contentValues, null, null);
+            Uri updateUri = ScheduleContract.addCallerIsSyncAdapterParameter(
+                    ScheduleContract.Feedback.buildFeedbackUri(sessionId));
+            cr.update(updateUri, contentValues, null, null);
         }
 
     }


### PR DESCRIPTION
Sets the CALLER_IS_SYNCADAPTER parameter when sending updates to
the ContentProvider for ScheduleContract.Feedback.

This prevents a temporary feedback loop when session feedback is
being synced.

Fixes issue #102.
