### PR TITLE
Fix for crashing navigation item background drawable

### DIFF
--- a/android/src/main/res/drawable-v21/selected_navdrawer_item_background.xml
+++ b/android/src/main/res/drawable-v21/selected_navdrawer_item_background.xml
@@ -13,6 +13,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#12000000" />
-</shape>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="#12000000" />
+        </shape>
+    </item>
+    <item android:drawable="?android:selectableItemBackground" />
+</layer-list>


### PR DESCRIPTION
Removed the erroneous `?android:selectableItemBackground` entry from the selected navigation item background in pre-Lollipop versions. The old drawable is kept in 21+ API versions.

This should fix issue #112.