### PR TITLE
[REPULL] Fix for crashing navigation item background drawable

### DIFF
--- a/android/src/main/res/drawable-v21/selected_navdrawer_item_background.xml
+++ b/android/src/main/res/drawable-v21/selected_navdrawer_item_background.xml
@@ -19,4 +19,5 @@
             <solid android:color="#12000000" />
         </shape>
     </item>
+    <item android:drawable="?android:selectableItemBackground" />
 </layer-list>


### PR DESCRIPTION
Note: Re-pull --> https://github.com/google/iosched/pull/119