### PR TITLE
Update scripts for CI server integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 # Copyright 2014 Google Inc. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,21 +17,17 @@ language: android
 android:
   components:
     - build-tools-21.1.2
-    - android-20
     - android-21
+    - addon-google_apis-google-21
     - extra-google-m2repository
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-21
+    - sys-img-armeabi-v7a-addon-google_apis-google-21
 
 notifications:
   email: false
 
-env:
-  matrix:
-    - ANDROID_TARGET=android-21  ANDROID_ABI=armeabi-v7a
-
 before_install:
-  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+  - echo no | android create avd --force -n test -t "Google Inc.:Google APIs:21" --abi google_apis/armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
 
 before_script:

--- a/scripts/wait_for_emulator.sh
+++ b/scripts/wait_for_emulator.sh
@@ -7,11 +7,11 @@ until [[ "$bootanim" =~ "stopped" ]]; do
    echo "$bootanim"
    if [[ "$bootanim" =~ "not found" ]]; then
       let "failcounter += 1"
-      if [[ $failcounter -gt 3 ]]; then
+      if [[ $failcounter -gt 6 ]]; then
         echo "Failed to start emulator"
         exit 1
       fi
    fi
-   sleep 1
+   sleep 10
 done
 echo "Done"


### PR DESCRIPTION
Update scripts/wait_for_emulator.sh to use a 60 second delay, with 10
seconds between checks. The old version only waited 3 seconds, which
was not long enough for the emulator to startup.

Also updated Android SDK dependencies in .travis.yml to use Google API
packages.