### PR TITLE
Fix issue #155 "Travis-ci configuration outdated"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@
 
 language: android
 
+sudo: false
+
 android:
   components:
-    - build-tools-21.1.2
-    - android-21
+    - platform-tool
+    - tool
+    - build-tools-23.0.1
+    - android-23
     - addon-google_apis-google-21
     - extra-google-m2repository
     - extra-android-m2repository
@@ -31,5 +35,10 @@ before_install:
   - emulator -avd test -no-skin -no-audio -no-window &
 
 before_script:
-  - ./scripts/wait_for_emulator.sh
+  - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  - wget -P android https://github.com/google/iosched/raw/0f7e56ff2588b816476fbad253554f49003e869d/android/debug.keystore
+
+script:
+  - ./gradlew clean android:assembleDebug server:assemble
+


### PR DESCRIPTION
1. Migrate from legacy to container-based infrastructure for faster builds adding `sudo: false`
2. Resque the android/debug.keystore from Iosched 2014 for CI usage using wget.
3. Update tools.
4. Travis-ci runs `./gradlew build connectedCheck` by default, `qualityassurance` buildType requires new proguard rules and server tests run and fail on build, so I suggest only assemble by now.