### PR TITLE
SlidingTabLayout optimalization for android 7.0+

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/ui/widget/SlidingTabLayout.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/widget/SlidingTabLayout.java
@@ -207,8 +207,13 @@ public class SlidingTabLayout extends HorizontalScrollView {
 
             if (mDistributeEvenly) {
                 LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams) tabView.getLayoutParams();
-                lp.width = 0;
                 lp.weight = 1;
+                if (Build.VERSION.SDK_INT < 24) {
+                    lp.width = 0;
+                }
+                else {
+                    lp.width = LinearLayout.LayoutParams.MATCH_PARENT;
+                }
             }
 
             tabTitleView.setText(adapter.getPageTitle(i));


### PR DESCRIPTION
In sdk 24+ layoutparams with width 0 create unwanted padding under active tab strip. Solved with MATCH_PARENT instead of 0.