### PR TITLE
Make sure type parameter of Event class is non-null

### DIFF
--- a/shared/src/main/java/com/google/samples/apps/iosched/shared/result/Event.kt
+++ b/shared/src/main/java/com/google/samples/apps/iosched/shared/result/Event.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.Observer
 /**
  * Used as a wrapper for data that is exposed via a LiveData that represents an event.
  */
-open class Event<out T>(private val content: T) {
+open class Event<out T : Any>(private val content: T) {
 
     var hasBeenHandled = false
         private set // Allow external read but not write
@@ -50,7 +50,7 @@ open class Event<out T>(private val content: T) {
  *
  * [onEventUnhandledContent] is *only* called if the [Event]'s contents has not been handled.
  */
-class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
+class EventObserver<T : Any>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
     override fun onChanged(event: Event<T>?) {
         event?.getContentIfNotHandled()?.let { value ->
             onEventUnhandledContent(value)


### PR DESCRIPTION
- `null` can't be used as a valid content of `Event` because `Event` uses `null` to indicate the event has been already handled
- It means the type parameter `T` of `Event` should never be nullable
- Expressed that constrain by giving upper bound `Any` to `T`
  - Reference: https://speakerdeck.com/npryce/the-kotlin-type-hierarchy-from-top-to-bottom?slide=27