### PR TITLE
Updated gradle wrapper version to fix Gradle project sync freezes

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Updating the Gradle version fixes this issue for me:

https://discuss.gradle.org/t/sync-taking-very-long-after-switching-to-kotlin-dsl-with-message-importing-build-script-classpath-data/36485