### PR TITLE
Upgrade to AGP 7.0.0-beta03

### DIFF
--- a/androidTest-shared/build.gradle.kts
+++ b/androidTest-shared/build.gradle.kts
@@ -20,17 +20,15 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
+    compileSdk = Versions.COMPILE_SDK
     defaultConfig {
-        minSdkVersion(Versions.MIN_SDK)
-        targetSdkVersion(Versions.TARGET_SDK)
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = Versions.MIN_SDK
+        targetSdk = Versions.TARGET_SDK
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    lintOptions {
+    lint {
         // Version changes are beyond our control, so don't warn. The IDE will still mark these.
         disable("GradleDependency")
     }

--- a/ar/build.gradle.kts
+++ b/ar/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import kotlin.reflect.full.memberFunctions
 
 /*

--- a/ar/build.gradle.kts
+++ b/ar/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlin.reflect.full.memberFunctions
+
 /*
  * Copyright 2020 Google LLC
  *
@@ -21,12 +23,10 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
+    compileSdk = Versions.COMPILE_SDK
     defaultConfig {
-        minSdkVersion(Versions.MIN_SDK)
-        targetSdkVersion(Versions.TARGET_SDK)
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = Versions.MIN_SDK
+        targetSdk = Versions.TARGET_SDK
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-proguard-rules.pro")
     }
@@ -34,17 +34,18 @@ android {
     buildTypes {
         maybeCreate("staging")
         getByName("staging") {
-            initWith(getByName("debug"))
+            // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
 
             // Specifies a sorted list of fallback build types that the
             // plugin should try to use when a dependency does not include a
             // "staging" build type.
             // Used with :test-shared, which doesn't have a staging variant.
-            setMatchingFallbacks(listOf("debug"))
+            matchingFallbacks += listOf("debug")
         }
     }
 
-    lintOptions {
+    lint {
         disable("InvalidPackage")
         // Version changes are beyond our control, so don't warn. The IDE will still mark these.
         disable("GradleDependency")

--- a/ar/build.gradle.kts
+++ b/ar/build.gradle.kts
@@ -35,6 +35,7 @@ android {
         maybeCreate("staging")
         getByName("staging") {
             // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            // https://issuetracker.google.com/issues/186798050
             this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
 
             // Specifies a sorted list of fallback build types that the

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.squareup.kotlinpoet.MemberName.Companion.member
+import kotlin.reflect.full.memberFunctions
+
 /*
  * Copyright 2020 Google LLC
  *
@@ -17,27 +20,24 @@
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
     id("androidx.benchmark")
     kotlin("kapt")
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
+    compileSdk = Versions.COMPILE_SDK
     defaultConfig {
-        minSdkVersion(Versions.MIN_SDK)
-        targetSdkVersion(Versions.TARGET_SDK)
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = Versions.MIN_SDK
+        targetSdk = Versions.TARGET_SDK
         testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
     }
 
     buildTypes {
         maybeCreate("staging")
         getByName("staging") {
-            initWith(getByName("debug"))
+            // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
             isDefault = true
-            versionNameSuffix = "-staging"
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
 
@@ -45,7 +45,7 @@ android {
             // plugin should try to use when a dependency does not include a
             // "staging" build type.
             // Used with :test-shared, which doesn't have a staging variant.
-            setMatchingFallbacks(listOf("debug"))
+            matchingFallbacks += listOf("debug")
         }
     }
 

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -36,6 +36,7 @@ android {
         maybeCreate("staging")
         getByName("staging") {
             // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            // https://issuetracker.google.com/issues/186798050 
             this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
             isDefault = true
             isMinifyEnabled = true

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,4 +1,19 @@
-import com.squareup.kotlinpoet.MemberName.Companion.member
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import kotlin.reflect.full.memberFunctions
 
 /*

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -23,14 +23,14 @@ object Versions {
     const val TARGET_SDK = 30
     const val MIN_SDK = 21
 
-    const val ANDROID_GRADLE_PLUGIN = "7.0.0-alpha14"
+    const val ANDROID_GRADLE_PLUGIN = "7.0.0-beta03"
     const val BENCHMARK = "1.0.0"
     const val COMPOSE = "1.0.0-beta04"
     const val FIREBASE_CRASHLYTICS = "2.3.0"
     const val GOOGLE_SERVICES = "4.3.3"
     const val KOTLIN = "1.4.32"
     const val NAVIGATION = "2.3.5"
-    const val HILT_AGP = "2.34-beta"
+    const val HILT_AGP = "2.36"
 
     // TODO: Remove this once the version for
     //  "org.threeten:threetenbp:${Versions.threetenbp}:no-tzdb" using java-platform in the

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Feb 10 08:38:31 CET 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlin.reflect.full.memberFunctions
+
 /*
  * Copyright 2020 Google LLC
  *
@@ -17,7 +19,6 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     id("androidx.navigation.safeargs.kotlin")
     id("com.google.firebase.crashlytics")
@@ -37,23 +38,23 @@ android {
         buildConfigField(
             "com.google.android.gms.maps.model.LatLng",
             "MAP_VIEWPORT_BOUND_NE",
-            "new com.google.android.gms.maps.model.LatLng(${properties["map_viewport_bound_ne"]})"
+            "new com.google.android.gms.maps.model.LatLng(${project.properties["map_viewport_bound_ne"]})"
         )
         buildConfigField(
             "com.google.android.gms.maps.model.LatLng",
             "MAP_VIEWPORT_BOUND_SW",
-            "new com.google.android.gms.maps.model.LatLng(${properties["map_viewport_bound_sw"]})"
+            "new com.google.android.gms.maps.model.LatLng(${project.properties["map_viewport_bound_sw"]})"
         )
 
-        buildConfigField("float", "MAP_CAMERA_FOCUS_ZOOM", properties["map_camera_focus_zoom"] as String)
+        buildConfigField("float", "MAP_CAMERA_FOCUS_ZOOM", project.properties["map_camera_focus_zoom"] as String)
 
-        resValue("dimen", "map_camera_bearing", properties["map_default_camera_bearing"] as String)
-        resValue("dimen", "map_camera_target_lat", properties["map_default_camera_target_lat"] as String)
-        resValue("dimen", "map_camera_target_lng", properties["map_default_camera_target_lng"] as String)
-        resValue("dimen", "map_camera_tilt", properties["map_default_camera_tilt"] as String)
-        resValue("dimen", "map_camera_zoom", properties["map_default_camera_zoom"] as String)
-        resValue("dimen", "map_viewport_min_zoom", properties["map_viewport_min_zoom"] as String)
-        resValue("dimen", "map_viewport_max_zoom", properties["map_viewport_max_zoom"] as String)
+        resValue("dimen", "map_camera_bearing", project.properties["map_default_camera_bearing"] as String)
+        resValue("dimen", "map_camera_target_lat", project.properties["map_default_camera_target_lat"] as String)
+        resValue("dimen", "map_camera_target_lng", project.properties["map_default_camera_target_lng"] as String)
+        resValue("dimen", "map_camera_tilt", project.properties["map_default_camera_tilt"] as String)
+        resValue("dimen", "map_camera_zoom", project.properties["map_default_camera_zoom"] as String)
+        resValue("dimen", "map_viewport_min_zoom", project.properties["map_viewport_min_zoom"] as String)
+        resValue("dimen", "map_viewport_max_zoom", project.properties["map_viewport_max_zoom"] as String)
 
         manifestPlaceholders["crashlyticsEnabled"] = true
 
@@ -93,14 +94,15 @@ android {
         }
         maybeCreate("staging")
         getByName("staging") {
-            initWith(getByName("debug"))
+            // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
             versionNameSuffix = "-staging"
 
             // Specifies a sorted list of fallback build types that the
             // plugin should try to use when a dependency does not include a
             // "staging" build type.
             // Used with :test-shared, which doesn't have a staging variant.
-            setMatchingFallbacks(listOf("debug"))
+            matchingFallbacks += listOf("debug")
         }
     }
 
@@ -134,7 +136,7 @@ android {
         }
     }
 
-    lintOptions {
+    lint {
         // Eliminates UnusedResources false positives for resources used in DataBinding layouts
         isCheckGeneratedSources = true
         // Running lint over the debug variant is enough
@@ -162,8 +164,8 @@ android {
     }
 
     packagingOptions {
-        exclude("META-INF/AL2.0")
-        exclude("META-INF/LGPL2.1")
+        resources.excludes += "META-INF/AL2.0"
+        resources.excludes += "META-INF/LGPL2.1"
     }
 }
 

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -95,6 +95,7 @@ android {
         maybeCreate("staging")
         getByName("staging") {
             // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            // https://issuetracker.google.com/issues/186798050
             this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
             versionNameSuffix = "-staging"
 

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import kotlin.reflect.full.memberFunctions
 
 /*

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import kotlin.reflect.full.memberFunctions
 
 /*

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlin.reflect.full.memberFunctions
+
 /*
  * Copyright 2020 Google LLC
  *
@@ -17,39 +19,36 @@
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     id("dagger.hilt.android.plugin")
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
+    compileSdk = Versions.COMPILE_SDK
     defaultConfig {
-        minSdkVersion(Versions.MIN_SDK)
-        targetSdkVersion(Versions.TARGET_SDK)
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = Versions.MIN_SDK
+        targetSdk = Versions.TARGET_SDK
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField("String", "CONFERENCE_TIMEZONE", properties["conference_timezone"] as String)
-        buildConfigField("String", "CONFERENCE_DAY1_START", properties["conference_day1_start"] as String)
-        buildConfigField("String", "CONFERENCE_DAY1_END", properties["conference_day1_end"] as String)
-        buildConfigField("String", "CONFERENCE_DAY2_START", properties["conference_day2_start"] as String)
-        buildConfigField("String", "CONFERENCE_DAY2_END", properties["conference_day2_end"] as String)
-        buildConfigField("String", "CONFERENCE_DAY3_START", properties["conference_day3_start"] as String)
-        buildConfigField("String", "CONFERENCE_DAY3_END", properties["conference_day3_end"] as String)
+        buildConfigField("String", "CONFERENCE_TIMEZONE", project.properties["conference_timezone"] as String)
+        buildConfigField("String", "CONFERENCE_DAY1_START", project.properties["conference_day1_start"] as String)
+        buildConfigField("String", "CONFERENCE_DAY1_END", project.properties["conference_day1_end"] as String)
+        buildConfigField("String", "CONFERENCE_DAY2_START", project.properties["conference_day2_start"] as String)
+        buildConfigField("String", "CONFERENCE_DAY2_END", project.properties["conference_day2_end"] as String)
+        buildConfigField("String", "CONFERENCE_DAY3_START", project.properties["conference_day3_start"] as String)
+        buildConfigField("String", "CONFERENCE_DAY3_END", project.properties["conference_day3_end"] as String)
 
-        buildConfigField("String", "CONFERENCE_DAY1_AFTERHOURS_START", properties["conference_day1_afterhours_start"] as String)
-        buildConfigField("String", "CONFERENCE_DAY2_CONCERT_START", properties["conference_day2_concert_start"] as String)
+        buildConfigField("String", "CONFERENCE_DAY1_AFTERHOURS_START", project.properties["conference_day1_afterhours_start"] as String)
+        buildConfigField("String", "CONFERENCE_DAY2_CONCERT_START", project.properties["conference_day2_concert_start"] as String)
 
         buildConfigField(
             "String",
-            "BOOTSTRAP_CONF_DATA_FILENAME", properties["bootstrap_conference_data_filename"] as String
+            "BOOTSTRAP_CONF_DATA_FILENAME", project.properties["bootstrap_conference_data_filename"] as String
         )
 
         buildConfigField(
             "String",
-            "CONFERENCE_WIFI_OFFERING_START", properties["conference_wifi_offering_start"] as String
+            "CONFERENCE_WIFI_OFFERING_START", project.properties["conference_wifi_offering_start"] as String
         )
 
         consumerProguardFiles("consumer-proguard-rules.pro")
@@ -72,17 +71,18 @@ android {
         }
         maybeCreate("staging")
         getByName("staging") {
-            initWith(getByName("debug"))
+            // TODO: replace with initWith(getByName("debug")) in 7.0.0-beta04
+            this::class.memberFunctions.first { it.name == "initWith" }.call(this, getByName("debug"))
 
             // Specifies a sorted list of fallback build types that the
             // plugin should try to use when a dependency does not include a
             // "staging" build type.
             // Used with :test-shared, which doesn't have a staging variant.
-            setMatchingFallbacks(listOf("debug"))
+            matchingFallbacks += listOf("debug")
         }
     }
 
-    lintOptions {
+    lint {
         disable("InvalidPackage", "MissingTranslation")
         // Version changes are beyond our control, so don't warn. The IDE will still mark these.
         disable("GradleDependency")


### PR DESCRIPTION
- Migrate deprecated DSLs
- Upgrade Hilt
- Remove deprecated kotlin-extensions plugin
- Workaround for `initWith` with reflection for now (to be removed with 7.0.0-beta04)