### PR TITLE
Fix IllegalStateException when open SessionFeedbackFragment

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -23,7 +23,7 @@ object Versions {
     const val TARGET_SDK = 30
     const val MIN_SDK = 21
 
-    const val ANDROID_GRADLE_PLUGIN = "7.0.0-beta05"
+    const val ANDROID_GRADLE_PLUGIN = "7.0.1"
     const val BENCHMARK = "1.0.0"
     const val COMPOSE = "1.0.0-beta04"
     const val FIREBASE_CRASHLYTICS = "2.3.0"

--- a/mobile/src/main/java/com/google/samples/apps/iosched/ui/sessiondetail/SessionFeedbackFragment.kt
+++ b/mobile/src/main/java/com/google/samples/apps/iosched/ui/sessiondetail/SessionFeedbackFragment.kt
@@ -32,7 +32,7 @@ import com.google.samples.apps.iosched.databinding.FragmentSessionFeedbackBindin
 import com.google.samples.apps.iosched.databinding.ItemQuestionBinding
 import com.google.samples.apps.iosched.model.SessionId
 import com.google.samples.apps.iosched.shared.result.data
-import com.google.samples.apps.iosched.util.launchAndRepeatWithViewLifecycle
+import com.google.samples.apps.iosched.util.launchAndRepeatWithDialogLifecycle
 import com.google.samples.apps.iosched.widget.SimpleRatingBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,7 +64,7 @@ class SessionFeedbackFragment : AppCompatDialogFragment() {
 
         questionAdapter.submitList(viewModel.questions)
 
-        launchAndRepeatWithViewLifecycle {
+        launchAndRepeatWithDialogLifecycle {
             viewModel.userSession.collect {
                 it.data?.let {
                     dialog?.setTitle(it.session.title)

--- a/mobile/src/main/java/com/google/samples/apps/iosched/util/UiUtils.kt
+++ b/mobile/src/main/java/com/google/samples/apps/iosched/util/UiUtils.kt
@@ -22,6 +22,7 @@ import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -63,6 +64,23 @@ inline fun Fragment.launchAndRepeatWithViewLifecycle(
 ) {
     viewLifecycleOwner.lifecycleScope.launch {
         viewLifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
+            block()
+        }
+    }
+}
+
+/**
+ * Launches a new coroutine and repeats `block` every time the DialogFragment's lifecycle
+ * is in and out of `minActiveState` lifecycle state.
+ * DialogFragment has a slightly different lifecycle so we can't use viewLifecycleOwner here.
+ * https://developer.android.com/guide/fragments/dialogs#lifecycle
+ */
+inline fun DialogFragment.launchAndRepeatWithDialogLifecycle(
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    crossinline block: suspend CoroutineScope.() -> Unit
+) {
+    lifecycleScope.launch {
+        lifecycle.repeatOnLifecycle(minActiveState) {
             block()
         }
     }


### PR DESCRIPTION
SessionFeedbackFragment crashes because of DialogFragment's slightly different lifecycle so I've added another extension function to serve the same purpose but with DialogFragment lifecycle according to this document: https://developer.android.com/guide/fragments/dialogs#lifecycle

`Note: When subscribing to lifecycle-aware components such as LiveData, you should never use viewLifecycleOwner as the LifecycleOwner in a DialogFragment that uses Dialogs. Instead, use the DialogFragment itself, or if you're using Jetpack Navigation, use the NavBackStackEntry.`



2021-08-31 11:33:56.398 5615-5615/com.google.samples.apps.iosched E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.google.samples.apps.iosched, PID: 5615
    java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
        at androidx.fragment.app.Fragment.getViewLifecycleOwner(Fragment.java:361)
        at com.google.samples.apps.iosched.ui.sessiondetail.SessionFeedbackFragment.onCreateDialog(SessionFeedbackFragment.kt:148)
        at androidx.fragment.app.DialogFragment.prepareDialog(DialogFragment.java:648)
        at androidx.fragment.app.DialogFragment.onGetLayoutInflater(DialogFragment.java:562)
        at com.google.samples.apps.iosched.ui.sessiondetail.Hilt_SessionFeedbackFragment.onGetLayoutInflater(Hilt_SessionFeedbackFragment.java:70)
        at androidx.fragment.app.Fragment.performGetLayoutInflater(Fragment.java:1654)
        at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:493)
        at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:282)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2189)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2100)
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2002)
        at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:524)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
