### PR TITLE
CI test job doesn't need to wait for build

### DIFF
--- a/.github/workflows/iosched.yaml
+++ b/.github/workflows/iosched.yaml
@@ -46,7 +46,6 @@ jobs:
           path: mobile/build/reports/
 
   test:
-    needs: build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
The CI test job doesn't need to wait for the build job to finish.
Removing the needs will speed up CI.