### PR TITLE
Fix compile issues & other minor updates

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,22 +15,22 @@
  */
 
 object Versions {
-    val versionName = "7.0.15" // X.Y.Z; X = Major, Y = minor, Z = Patch level
-    private val versionCodeBase = 70150 // XYYZZM; M = Module (tv, mobile)
-    val versionCodeMobile = versionCodeBase + 3
+    const val versionName = "7.0.15" // X.Y.Z; X = Major, Y = minor, Z = Patch level
+    private const val versionCodeBase = 70150 // XYYZZM; M = Module (tv, mobile)
+    const val versionCodeMobile = versionCodeBase + 3
 
     const val COMPILE_SDK = 30
     const val TARGET_SDK = 30
     const val MIN_SDK = 21
 
-    const val ANDROID_GRADLE_PLUGIN = "7.0.0-beta05"
+    const val ANDROID_GRADLE_PLUGIN = "7.0.2"
     const val BENCHMARK = "1.0.0"
     const val COMPOSE = "1.0.0-beta04"
     const val FIREBASE_CRASHLYTICS = "2.3.0"
     const val GOOGLE_SERVICES = "4.3.3"
     const val KOTLIN = "1.4.32"
     const val NAVIGATION = "2.3.5"
-    const val HILT_AGP = "2.36"
+    const val HILT_AGP = "2.38.1"
 
     // TODO: Remove this once the version for
     //  "org.threeten:threetenbp:${Versions.threetenbp}:no-tzdb" using java-platform in the

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -42,11 +42,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.COMPILE_SDK)
+    compileSdk=Versions.COMPILE_SDK
     defaultConfig {
         applicationId = "com.google.samples.apps.iosched"
-        minSdkVersion(Versions.MIN_SDK)
-        targetSdkVersion(Versions.TARGET_SDK)
+        minSdk = Versions.MIN_SDK
+        targetSdk = Versions.TARGET_SDK
         versionCode = Versions.versionCodeMobile
         versionName = Versions.versionName
         testInstrumentationRunner = "com.google.samples.apps.iosched.tests.CustomTestRunner"


### PR DESCRIPTION
Currently cloning the repo & building the app fails (see issue #401 & #403 ). 

- Seems to be a problem with AGP & Hilt Gradle plugin version issue. Hence updated both to `7.0.2` and `2.38.1` respectively.   
 ( ⚠️  Updating AGP to latest `7.2.X` doesn't seem to solve the compilation issue hence used `7.0.2` )
- Updated to use const for `versionName`, `versionCodeBase` & `versionCodeMobile` in `Versions.kt`
- Updated to property access instead of deprecated functions for minSdk, compileSdk & targetSdk in `:mobile` `build.gradle.kts`
